### PR TITLE
Convert a VDI.introduce into a Volume.stat

### DIFF
--- a/main.ml
+++ b/main.ml
@@ -425,6 +425,21 @@ let process root_dir name x =
     >>= fun response ->
     let response = vdi_of_volume response in
     Deferred.Result.return (R.success (Args.VDI.Stat.rpc_of_response response))
+  | { R.name = "VDI.introduce"; R.params = [ args ] } ->
+    let open Deferred.Result.Monad_infix in
+    let args = Args.VDI.Introduce.request_of_rpc args in
+    Attached_SRs.find args.Args.VDI.Introduce.sr
+    >>= fun sr ->
+    let vdi = args.Args.VDI.Introduce.location in
+    let args = Storage.Volume.Types.Volume.Stat.In.make
+      args.Args.VDI.Introduce.dbg
+      sr
+      vdi in
+    let args = Storage.Volume.Types.Volume.Stat.In.rpc_of_t args in
+    fork_exec_rpc root_dir (script root_dir name `Volume "Volume.stat") args Storage.Volume.Types.Volume.Stat.Out.t_of_rpc
+    >>= fun response ->
+    let response = vdi_of_volume response in
+    Deferred.Result.return (R.success (Args.VDI.Introduce.rpc_of_response response))
   | { R.name = "VDI.attach"; R.params = [ args ] } ->
     let open Deferred.Result.Monad_infix in
     let args = Args.VDI.Attach.request_of_rpc args in


### PR DESCRIPTION
The xapi layer will take care of creating the database record when
it receives a successful result.

This depends on [xapi-project/xcp-idl#81]

Signed-off-by: David Scott <dave.scott@eu.citrix.com>