### PR TITLE
Clone on boot

### DIFF
--- a/main.ml
+++ b/main.ml
@@ -227,7 +227,7 @@ let choose_datapath ?(persistent = true) response =
       let uri = Uri.of_string x in
       match Uri.scheme uri with
       | None -> None
-      | Some scheme -> Some (scheme, uri)
+      | Some scheme -> Some (scheme, x)
     ) response.Storage.Volume.Types.uri in
   (* We can only use URIs whose schemes correspond to registered plugins *)
   let possible = List.filter ~f:(fun (scheme, _) -> Hashtbl.mem !Datapath_plugins.table scheme) possible in
@@ -243,7 +243,7 @@ let choose_datapath ?(persistent = true) response =
       supports_nonpersistent @ others in
   match preference_order with
   | [] -> return (Error (missing_uri ()))
-  | (scheme, u) :: us -> return (Ok (scheme, Uri.to_string u, "0"))
+  | (scheme, u) :: us -> return (Ok (scheme, u, "0"))
 
 (* Process a message *)
 let process root_dir name x =

--- a/main.ml
+++ b/main.ml
@@ -665,6 +665,13 @@ let process root_dir name x =
     end else begin
       (* We create a non-persistent disk here with Volume.clone, and store
          the name of the cloned disk in the metadata of the original. *)
+      ( match List.Assoc.find response.Storage.Volume.Types.keys _clone_on_boot_key with
+        | None ->
+          return (Ok ())
+        | Some temporary ->
+          (* Destroy the temporary disk we made earlier *)
+          destroy root_dir name args.Args.VDI.Epoch_begin.dbg sr temporary
+      ) >>= fun () ->
       clone root_dir name args.Args.VDI.Epoch_begin.dbg sr args.Args.VDI.Epoch_begin.vdi
       >>= fun vdi ->
       set root_dir name args.Args.VDI.Epoch_begin.dbg sr args.Args.VDI.Epoch_begin.vdi _clone_on_boot_key vdi.Storage.Volume.Types.key

--- a/main.ml
+++ b/main.ml
@@ -219,6 +219,11 @@ let set root_dir name dbg sr vdi k v =
   let args = Storage.Volume.Types.Volume.Set.In.rpc_of_t args in
   fork_exec_rpc root_dir (script root_dir name `Volume "Volume.set") args Storage.Volume.Types.Volume.Set.Out.t_of_rpc
 
+let unset root_dir name dbg sr vdi k =
+  let args = Storage.Volume.Types.Volume.Unset.In.make dbg sr vdi k in
+  let args = Storage.Volume.Types.Volume.Unset.In.rpc_of_t args in
+  fork_exec_rpc root_dir (script root_dir name `Volume "Volume.unset") args Storage.Volume.Types.Volume.Unset.Out.t_of_rpc
+
 let choose_datapath ?(persistent = true) response =
   (* We can only use a URI with a valid scheme, since we use the scheme
      to name the datapath plugin. *)
@@ -703,6 +708,8 @@ let process root_dir name x =
       | Some temporary ->
         (* Destroy the temporary disk we made earlier *)
         destroy root_dir name args.Args.VDI.Epoch_end.dbg sr temporary
+        >>= fun () ->
+        unset root_dir name args.Args.VDI.Epoch_end.dbg sr args.Args.VDI.Epoch_end.vdi _clone_on_boot_key
         >>= fun () ->
         Deferred.Result.return (R.success (Args.VDI.Epoch_end.rpc_of_response ()))
     end

--- a/main.ml
+++ b/main.ml
@@ -706,6 +706,10 @@ let process root_dir name x =
         >>= fun () ->
         Deferred.Result.return (R.success (Args.VDI.Epoch_end.rpc_of_response ()))
     end
+  | { R.name = "VDI.set_persistent"; R.params = [ args ] } ->
+    let open Deferred.Result.Monad_infix in
+    (* We don't do anything until the VDI.epoch_begin *)
+    Deferred.Result.return (R.success (Args.VDI.Set_persistent.rpc_of_response ()))
   | { R.name = name } ->
     Deferred.return (Error (backend_error "UNIMPLEMENTED" [ name ])))
   >>= function


### PR DESCRIPTION
If `Volume.stat` returns multiple URIs, we will prefer to use a datapath plugin that exposes the `NONPERSISTENT` feature. Otherwise we will fall back to using `Volume.clone`.

Note that we use the new `Volume.set` and `Volume.unset` to store the key of the temporary clone-on-boot volume. We dereference this pointer before `Datapath.attach` etc. We omit these temporary volumes from `SR.ls` and we guarantee to clean them up on `VDI.epoch_end`, `VDI.destroy`, or `VDI.attach` (in the case where one leaked over a crashed and the VM restarted).