### PR TITLE
CP-13837: plumb through XenAPI-style errors

### DIFF
--- a/types.ml
+++ b/types.ml
@@ -13,10 +13,16 @@
  *)
 open Sexplib.Std
 
-(* This matches xapi.py:exception *)
-type error = {
+type backtrace = {
   error: string;
   (* Python json.dumps and rpclib are not very friendly *)
   files: string list;
   lines: int list;
+} with rpc
+
+(* This matches xapi.py:exception *)
+type error = {
+  code: string;
+  params: string list;
+  backtrace: backtrace;
 } with rpc


### PR DESCRIPTION
We subdivide the `type error` into 3:

- `type backtrace`: this has the backtrace information, in the format
  expected by `Backtrace.Interop.of_json`
- `code`: this is the XenAPI error code (e.g. `SR_BACKEND_FAILURE_1`)
- `params`: this is the XenAPI error argument list

When received by `xapi-storage-script`, the error is converted into a
SMAPIv2 `Backend_error_with_backtrace` exception.

Signed-off-by: David Scott <dave.scott@citrix.com>