### PR TITLE
CA-272163: convert exceptions from SMAPIv3 backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-opam.sh
 sudo: true
 env:
-        - OCAML_VERSION=4.02 PACKAGE=xapi-storage-script PINS="xapi-storage:git://github.com/djs55/xapi-storage" EXTRA_REMOTES="git://github.com/xapi-project/opam-repo-dev"
+    - OCAML_VERSION=4.04 PACKAGE=xapi-storage-script PINS="xapi-storage:git://github.com/xapi-project/xapi-storage#feature/REQ477/master xapi-idl:git://github.com/xapi-project/xcp-idl#feature/REQ477/master xcp:git://github.com/xapi-project/xcp-idl#feature/REQ477/master" EXTRA_REMOTES="git://github.com/xapi-project/xs-opam#2.1.0"

--- a/main.ml
+++ b/main.ml
@@ -78,9 +78,15 @@ let backend_error name args =
   Exception.rpc_of_exnty exnty
 
 let backend_backtrace_error name args backtrace =
-  let backtrace = rpc_of_backtrace backtrace |> Jsonrpc.to_string in
   let open Storage_interface in
-  let exnty = Exception.Backend_error_with_backtrace(name, backtrace :: args) in
+  let exnty =
+    match args with
+    | ["Activated_on_another_host"; uuid] ->
+       Exception.Activated_on_another_host(uuid)
+    | _ ->
+       let backtrace = rpc_of_backtrace backtrace |> Jsonrpc.to_string in
+       Exception.Backend_error_with_backtrace(name, backtrace :: args)
+  in
   Exception.rpc_of_exnty exnty
 
 let missing_uri () =

--- a/opam
+++ b/opam
@@ -1,7 +1,11 @@
-opam-version: "1"
-maintainer: "dave.scott@citrix.com"
-build: [
-  [make]
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/xapi-storage-script"
+bug-reports: "https://github.com/xapi-project/xapi-storage-script/issues"
+dev-repo: "git+https://github.com/xapi-project/xapi-storage-script.git"
+build: [[make]]
+install:[
   [make "install" "BINDIR=%{bin}%" "MANDIR=%{man}%"]
 ]
 remove: [


### PR DESCRIPTION
When xapi-storage-plugins raises an exception [Activated_on_another_host](https://github.com/xapi-project/xapi-storage-plugins/blob/feature/REQ477/master/libs/libcow/volume.py#L164) we need to transform it back to an exception that XAPI understands and [expects](https://github.com/xapi-project/xen-api/blob/feature/REQ477/master/ocaml/xapi/storage_mux.ml#L202), not the generic backend error.

After the modification in [xapi-storage PR](https://github.com/xapi-project/xapi-storage/pull/66) we will have access to the name of the exception, not just its parameters and we can do this transformation.

With these two PRs I am able to successfully take a snapshot of a running VM on a slave.