### PR TITLE
[477 idl part2] sharable flag, SR.create and SR.attach API change

### DIFF
--- a/main.ml
+++ b/main.ml
@@ -78,9 +78,15 @@ let backend_error name args =
   Exception.rpc_of_exnty exnty
 
 let backend_backtrace_error name args backtrace =
-  let backtrace = rpc_of_backtrace backtrace |> Jsonrpc.to_string in
   let open Storage_interface in
-  let exnty = Exception.Backend_error_with_backtrace(name, backtrace :: args) in
+  let exnty =
+    match args with
+    | ["Activated_on_another_host"; uuid] ->
+       Exception.Activated_on_another_host(uuid)
+    | _ ->
+       let backtrace = rpc_of_backtrace backtrace |> Jsonrpc.to_string in
+       Exception.Backend_error_with_backtrace(name, backtrace :: args)
+  in
   Exception.rpc_of_exnty exnty
 
 let missing_uri () =

--- a/main.ml
+++ b/main.ml
@@ -417,12 +417,13 @@ let process root_dir name x =
     Deferred.Result.return (R.success (Args.Query.Diagnostics.rpc_of_response response))
   | { R.name = "SR.attach"; R.params = [ args ] } ->
     let args = Args.SR.Attach.request_of_rpc args in
+    let uuid = args.Args.SR.Attach.sr in
     let device_config = args.Args.SR.Attach.device_config in
     begin match List.find device_config ~f:(fun (k, _) -> k = "uri") with
     | None ->
       Deferred.Result.return (R.failure (missing_uri ()))
     | Some (_, uri) ->
-      let args' = Xapi_storage.Volume.Types.SR.Attach.In.make args.Args.SR.Attach.dbg uri in
+      let args' = Xapi_storage.Volume.Types.SR.Attach.In.make args.Args.SR.Attach.dbg uuid uri in
       let args' = Xapi_storage.Volume.Types.SR.Attach.In.rpc_of_t args' in
       let open Deferred.Result.Monad_infix in
       fork_exec_rpc root_dir (script root_dir name `Volume "SR.attach") args' Xapi_storage.Volume.Types.SR.Attach.Out.t_of_rpc

--- a/main.ml
+++ b/main.ml
@@ -255,6 +255,7 @@ let vdi_of_volume x =
   virtual_size = x.Xapi_storage.Volume.Types.virtual_size;
   physical_utilisation = x.Xapi_storage.Volume.Types.physical_utilisation;
   sm_config = [];
+  sharable = x.Storage.Volume.Types.sharable;
   persistent = true;
 }
 
@@ -597,7 +598,8 @@ let process root_dir name x =
       sr
       vdi_info.name_label
       vdi_info.name_description
-      vdi_info.virtual_size in
+      vdi_info.virtual_size
+      vdi_info.sharable in
     let args = Xapi_storage.Volume.Types.Volume.Create.In.rpc_of_t args in
     fork_exec_rpc root_dir (script root_dir name `Volume "Volume.create") args Xapi_storage.Volume.Types.Volume.Create.Out.t_of_rpc
     >>= fun response ->

--- a/xapi_storage_script_types.ml
+++ b/xapi_storage_script_types.ml
@@ -11,7 +11,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-open Sexplib.Std
 
 type backtrace = {
   error: string;


### PR DESCRIPTION
This is part of the SMAPIv3 interface  change from `feature/REQ477/master`,
has to be merged together with these PRs:
xapi-project/sm-cli#26
xapi-project/xapi-storage#70
xapi-project/xcp-idl#202
https://github.com/xapi-project/xen-api/pull/3433

The sharable flag is explained in the xcp-idl commit: https://github.com/xapi-project/xcp-idl/commit/c8bfaf9d61c547df42fac12f5d05b0165e24b83b
The activated on exception/redirection is explained here (SMAPIv3 can require snapshots to be taken on the host that has the VM running, instead of the master): https://github.com/xapi-project/xen-api/commit/620acd20e2753a7f10a970e6f1850b325fea082a

SMAPIv3: `SR.create` and `SR.attach` need an uuid parameter too, this is a breaking API change, the xapi PR updates XAPI accordingly.