### PR TITLE
Report SR_PROBE capability

### DIFF
--- a/main.ml
+++ b/main.ml
@@ -420,6 +420,7 @@ let process root_dir name =
       "SR.detach",       "SR_DETACH";
       "SR.ls",           "SR_SCAN";
       "SR.stat",         "SR_UPDATE";
+      "SR.probe",        "SR_PROBE";
       "Volume.create",   "VDI_CREATE";
       "Volume.clone",    "VDI_CLONE";
       "Volume.snapshot", "VDI_SNAPSHOT";


### PR DESCRIPTION
This is okay to do now, because SR.probe works for SMAPIv3 SRs too: we
try to reconstruct the same XML structure that is returned by SMAPIv1
SRs.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>