### PR TITLE
CP-27591: Convert to new xapi-storage interface based on ocaml-rpc's IDL

### DIFF
--- a/main.ml
+++ b/main.ml
@@ -20,6 +20,71 @@ open Async
 
 open Xapi_storage_script_types
 
+module Plugin_client = Xapi_storage.Plugin.Plugin(Rpc_async.GenClient ())
+module Volume_client = Xapi_storage.Control.Volume(Rpc_async.GenClient ())
+module Sr_client = Xapi_storage.Control.Sr(Rpc_async.GenClient ())
+module Datapath_client = Xapi_storage.Data.Datapath(Rpc_async.GenClient ())
+
+let (>>>=) = Deferred.Result.(>>=)
+
+(** Functions for returning SMAPIv2 errors *)
+
+(** Exception returned by fork_exec_rpc when the script invocation fails *)
+exception Fork_exec_error of Storage_interface.Exception.exnty
+
+let backend_error name args =
+  let open Storage_interface in
+  Exception.Backend_error (name, args)
+
+let backend_backtrace_error name args backtrace =
+  let open Storage_interface in
+  match args with
+  | ["Activated_on_another_host"; uuid] ->
+     Exception.Activated_on_another_host(uuid)
+  | _ ->
+     let backtrace = rpc_of_backtrace backtrace |> Jsonrpc.to_string in
+     Exception.Backend_error_with_backtrace(name, backtrace :: args)
+
+let missing_uri () =
+  backend_error "MISSING_URI" [ "Please include a URI in the device-config" ]
+
+(** Functions to wrap calls to the above client modules and convert their
+    exceptions and errors into SMAPIv2 errors of type
+    [Storage_interface.Exception.exnty]. The above client modules should only
+    be used with these functions, otherwise the Fork_exec_error exception
+    raised by fork_exec_rpc will not be caught and the main thread will fail. *)
+
+(* fork_exec_rpc either raises a Fork_exec_error exception or
+   returns a successful RPC response *)
+let return_rpc typ result =
+  (* Operator to unwrap the wrapped async return type of ocaml-rpc's Rpc_async *)
+  let (>*=) a b = a |> Rpc_async.M.deferred >>= b in
+  Monitor.try_with
+    ~extract_exn:true
+    (fun () ->
+       (* We need to delay the evaluation of [result] until now, because
+          when fork_exec_rpc is called by GenClient.declare, it
+          might immediately raise a Fork_exec_error *)
+       (result ()) >*= fun result ->
+         (* In practice we'll always get a successful RPC response here (Ok),
+            but we still have to transform the Error to make the types match: *)
+         let result = Result.map_error
+             result
+             ~f:(fun err -> backend_error "SCRIPT_RETURNED_RPC_ERROR" [ Rpcmarshal.marshal typ err |> R.to_string ])
+         in
+         return result
+    )
+  >>= function
+  | Ok result -> return result
+  | Error (Fork_exec_error err) -> return (Error err)
+  (* We should not get any other exception from fork_exec_rpc: *)
+  | Error e -> return (Error (backend_error "SCRIPT_FAILED" [ "Unexpected exception:" ^ (Exn.to_string e) ]))
+
+let return_volume_rpc result = return_rpc Xapi_storage.Control.typ_of_exns result
+let return_plugin_rpc result = return_rpc Xapi_storage.Common.typ_of_exnt result
+let return_data_rpc result = return_rpc Xapi_storage.Common.typ_of_exnt result
+
+
 let use_syslog = ref false
 
 let log level fmt =
@@ -70,103 +135,128 @@ let _clone_on_boot_key = "clone-on-boot"
 let _vdi_type_key = "vdi-type"
 let _snapshot_time_key = "snapshot_time"
 
-let backend_error name args =
-  let open Storage_interface in
-  let exnty = Exception.Backend_error (name, args) in
-  Exception.rpc_of_exnty exnty
-
-let backend_backtrace_error name args backtrace =
-  let open Storage_interface in
-  let exnty =
-    match args with
-    | ["Activated_on_another_host"; uuid] ->
-       Exception.Activated_on_another_host(uuid)
-    | _ ->
-       let backtrace = rpc_of_backtrace backtrace |> Jsonrpc.to_string in
-       Exception.Backend_error_with_backtrace(name, backtrace :: args)
+let script_path ~script_dir ~call_name =
+  (* Deal with special cases: the name of the Plugin.query script does not
+     match the RPC function name *)
+  let script_name = match call_name with
+    | "Plugin.query" -> "Plugin.Query"
+    | call -> call
   in
-  Exception.rpc_of_exnty exnty
+  Filename.concat script_dir script_name
 
-let missing_uri () =
-  backend_error "MISSING_URI" [ "Please include a URI in the device-config" ]
+let id = fun x -> x
 
-let (>>>=) = Deferred.Result.(>>=)
-
-let fork_exec_rpc ?missing root_dir script_name args response_of_rpc =
-  info "%s %s" script_name (Jsonrpc.to_string args);
-  Sys.is_file ~follow_symlinks:true script_name
+(** Call the script named after the RPC method in the [script_dir]
+    directory. The arguments (not the whole JSON-RPC call) are passed as JSON
+    to its stdin, and stdout is returned. In case of a non-zero exit code,
+    stdout is treated as the error report.
+    The rest of the parameters are for compatiblity with the old PVS scripts:
+    - The PVS storage scripts are missing some calls. If [missing] is [Some
+      value], this [value] will be returned in case the required script is missing.
+    - If [compat_in] or [compat_out] are defined, they will convert the input to
+      the script and the output from the script, respectively, to ensure that
+      the script can understand the input and that rpclib can unmarshal its
+      output.
+    This function either returns a successful RPC response, or raises
+    Fork_exec_error with a suitable SMAPIv2 error if the call failed. *)
+let fork_exec_rpc ~script_dir ?missing ?(compat_in=id) ?(compat_out=id) =
+  let script_rpc call =
+    let script_name = script_path ~script_dir ~call_name:call.R.name in
+    info "%s %s" script_name (Jsonrpc.string_of_call call);
+    Sys.is_file ~follow_symlinks:true script_name
+      >>= function
+      | `No | `Unknown ->
+        error "%s is not a file" script_name;
+        (match missing with
+        | None ->
+          return (Error(backend_error "SCRIPT_MISSING" [ script_name; "Check whether the file exists and has correct permissions" ]))
+        | Some m ->
+          warn "Deprecated: script '%s' is missing, treating as no-op. Update your plugin!" script_name;
+          return (Ok (R.success m)))
+      | `Yes ->
+    ( Unix.access script_name [ `Exec ]
+      >>= function
+      | Error exn ->
+        error "%s is not executable" script_name;
+        return (Error (backend_error "SCRIPT_NOT_EXECUTABLE" [ script_name; Exn.to_string exn ]))
+      | Ok () -> return (Ok ())
+    ) >>>= fun () ->
+    Process.create ~prog:script_name ~args:["--json"] ()
     >>= function
-    | `No | `Unknown ->
-      error "%s is not a file" script_name;
-      (match missing with
-      | None ->
-        return (Error(backend_error "SCRIPT_MISSING" [ script_name; "Check whether the file exists and has correct permissions" ]))
-      | Some m ->
-        warn "Deprecated: script '%s' is missing, treating as no-op. Update your plugin!" script_name;
-        return (Ok m))
-    | `Yes ->
-  ( Unix.access script_name [ `Exec ]
-    >>= function
-    | Error exn ->
-      error "%s is not executable" script_name;
-      return (Error (backend_error "SCRIPT_NOT_EXECUTABLE" [ script_name; Exn.to_string exn ]))
-    | Ok () -> return (Ok ())
-  ) >>>= fun () ->
-  Process.create ~prog:script_name ~args:["--json"] ~working_dir:root_dir ()
-  >>= function
-  | Error e ->
-    error "%s failed: %s" script_name (Error.to_string_hum e);
-    return (Error(backend_error "SCRIPT_FAILED" [ script_name; Error.to_string_hum e ]))
-  | Ok p ->
-    (* Send the request as json on stdin *)
-    let w = Process.stdin p in
-    Writer.write w (Jsonrpc.to_string args);
-    Writer.close w
-    >>= fun () ->
-    Process.collect_output_and_wait p
-    >>= fun output ->
-    begin match output.Process.Output.exit_status with
-    | Error (`Exit_non_zero code) ->
-      (* Expect an exception and backtrace on stdout *)
-      begin match Or_error.try_with (fun () -> Jsonrpc.of_string output.Process.Output.stdout) with
-      | Error _ ->
-        error "%s failed and printed bad error json: %s" script_name output.Process.Output.stdout;
-        error "%s failed, stderr: %s" script_name output.Process.Output.stderr;
-        return (Error (backend_error "SCRIPT_FAILED" [ script_name; "non-zero exit and bad json on stdout"; string_of_int code; output.Process.Output.stdout; output.Process.Output.stdout ]))
-      | Ok response ->
-        begin match Or_error.try_with (fun () -> error_of_rpc response) with
+    | Error e ->
+      error "%s failed: %s" script_name (Error.to_string_hum e);
+      return (Error(backend_error "SCRIPT_FAILED" [ script_name; Error.to_string_hum e ]))
+    | Ok p ->
+      (* Send the request as json on stdin *)
+      let w = Process.stdin p in
+      (* We pass just the args, not the complete JSON-RPC call.
+         Currently the Python code generated by rpclib requires all params to
+         be named - they will be converted into a name->value Python dict.
+         Rpclib currently puts all named params into a dict, so we expect
+         params to be a single Dict, if all the params are named. *)
+      (match call.R.params with
+       | [R.Dict _ as d] ->
+         return (Ok d)
+       | _ -> return (Error (backend_error "INCORRECT_PARAMETERS" [ script_name; "All the call parameters should be named and should be in a RPC Dict" ]))
+      ) >>>= fun args ->
+      let args = compat_in args in
+      Writer.write w (Jsonrpc.to_string args);
+      Writer.close w
+      >>= fun () ->
+      Process.collect_output_and_wait p
+      >>= fun output ->
+      begin match output.Process.Output.exit_status with
+      | Error (`Exit_non_zero code) ->
+        (* Expect an exception and backtrace on stdout *)
+        begin match Or_error.try_with (fun () -> Jsonrpc.of_string output.Process.Output.stdout) with
         | Error _ ->
           error "%s failed and printed bad error json: %s" script_name output.Process.Output.stdout;
           error "%s failed, stderr: %s" script_name output.Process.Output.stderr;
           return (Error (backend_error "SCRIPT_FAILED" [ script_name; "non-zero exit and bad json on stdout"; string_of_int code; output.Process.Output.stdout; output.Process.Output.stdout ]))
-        | Ok x -> return (Error(backend_backtrace_error x.code x.params x.backtrace))
+        | Ok response ->
+          begin match Or_error.try_with (fun () -> error_of_rpc response) with
+          | Error _ ->
+            error "%s failed and printed bad error json: %s" script_name output.Process.Output.stdout;
+            error "%s failed, stderr: %s" script_name output.Process.Output.stderr;
+            return (Error (backend_error "SCRIPT_FAILED" [ script_name; "non-zero exit and bad json on stdout"; string_of_int code; output.Process.Output.stdout; output.Process.Output.stdout ]))
+          | Ok x -> return (Error(backend_backtrace_error x.code x.params x.backtrace))
+          end
         end
-      end
-    | Error (`Signal signal) ->
-      error "%s caught a signal and failed" script_name;
-      return (Error (backend_error "SCRIPT_FAILED" [ script_name; "signalled"; Signal.to_string signal; output.Process.Output.stdout; output.Process.Output.stdout ]))
-    | Ok () ->
+      | Error (`Signal signal) ->
+        error "%s caught a signal and failed" script_name;
+        return (Error (backend_error "SCRIPT_FAILED" [ script_name; "signalled"; Signal.to_string signal; output.Process.Output.stdout; output.Process.Output.stdout ]))
+      | Ok () ->
 
-      (* Parse the json on stdout *)
-      begin match Or_error.try_with (fun () -> Jsonrpc.of_string output.Process.Output.stdout) with
-      | Error _ ->
-        error "%s succeeded but printed bad json: %s" script_name output.Process.Output.stdout;
-        return (Error (backend_error "SCRIPT_FAILED" [ script_name; "bad json on stdout"; output.Process.Output.stdout ]))
-      | Ok response ->
-        begin match Or_error.try_with (fun () -> response_of_rpc response) with
-        | Error e ->
-          error "%s succeeded but printed bad json (%s): %s" script_name (Error.to_string_hum e) output.Process.Output.stdout;
-          return (Error (backend_error "SCRIPT_FAILED" [ script_name; "json did not match schema"; output.Process.Output.stdout ]))
-        | Ok x ->
+        (* Parse the json on stdout. We get back a JSON-RPC
+           value from the scripts, not a complete JSON-RPC response *)
+        begin match Or_error.try_with (fun () -> Jsonrpc.of_string output.Process.Output.stdout) with
+        | Error _ ->
+          error "%s succeeded but printed bad json: %s" script_name output.Process.Output.stdout;
+          return (Error (backend_error "SCRIPT_FAILED" [ script_name; "bad json on stdout"; output.Process.Output.stdout ]))
+        | Ok response ->
           info "%s succeeded: %s" script_name output.Process.Output.stdout;
-          return (Ok x)
+          let response = compat_out response in
+          let response = R.success response in
+          return (Ok response)
         end
       end
-    end
+  in
 
-let script root_dir name kind script = match kind with
-| `Volume -> Filename.(concat (concat root_dir name) script)
-| `Datapath datapath -> Filename.(concat (concat (concat (dirname root_dir) "datapath") datapath) script)
+  (* The Errors we return from this function and the special error format
+     returned by the scripts are not included in the error types of the various
+     SMAPIv3 interfaces, therefore we have to propagate them as exceptions
+     instead of returning an RPC call with an error, because rpclib would fail
+     to unmarshal that error.
+     Therefore we either return a successful RPC response, or raise
+     Fork_exec_error with a suitable SMAPIv2 error if the call failed. *)
+  let rpc call =
+    script_rpc call >>= fun result ->
+    Result.map_error ~f:(fun e -> Fork_exec_error e) result
+    |> Result.ok_exn
+    |> return
+  in
+
+  rpc
 
 module Attached_SRs = struct
   type state = {
@@ -194,16 +284,14 @@ module Attached_SRs = struct
     match Hashtbl.find !sr_table smapiv2 with
     | None ->
       let open Storage_interface in
-      let exnty = Exception.Sr_not_attached smapiv2 in
-      return (Error (Exception.rpc_of_exnty exnty))
+      return (Error (Exception.Sr_not_attached smapiv2))
     | Some { sr; _ } -> return (Ok sr)
 
   let get_uids smapiv2 =
     match Hashtbl.find !sr_table smapiv2 with
     | None ->
       let open Storage_interface in
-      let exnty = Exception.Sr_not_attached smapiv2 in
-      return (Error (Exception.rpc_of_exnty exnty))
+      return (Error (Exception.Sr_not_attached smapiv2))
     | Some { uids; _ } -> return (Ok uids)
 
   let remove smapiv2 =
@@ -224,97 +312,129 @@ module Attached_SRs = struct
 end
 
 module Datapath_plugins = struct
-  let table: Xapi_storage.Plugin.Types.query_result String.Table.t ref = ref (String.Table.create ())
+  let table = String.Table.create ()
 
-  let register root_dir name =
-    let args = Xapi_storage.Plugin.Types.Plugin.Query.In.make "register" in
-    let args = Xapi_storage.Plugin.Types.Plugin.Query.In.rpc_of_t args in
-    fork_exec_rpc root_dir (script root_dir name (`Datapath name) "Plugin.Query") args Xapi_storage.Plugin.Types.Plugin.Query.Out.t_of_rpc
-    >>= function
+  let register ~datapath_root datapath_plugin_name =
+    let script_dir = Filename.concat datapath_root datapath_plugin_name in
+    return_plugin_rpc (fun () -> Plugin_client.query (fork_exec_rpc ~script_dir) "register")
+    >>= fun result ->
+    match result with
     | Ok response ->
-      info "Registered datapath plugin %s" name;
-      Hashtbl.set !table ~key:name ~data:response;
+      info "Registered datapath plugin %s" datapath_plugin_name;
+      Hashtbl.set table ~key:datapath_plugin_name ~data:(script_dir, response);
       return ()
-    | _ ->
-      info "Failed to register datapath plugin %s" name;
+    | Error _ ->
+      info "Failed to register datapath plugin %s" datapath_plugin_name;
       return ()
 
-  let unregister root_dir name =
-    Hashtbl.remove !table name;
+  let unregister datapath_plugin_name =
+    Hashtbl.remove table datapath_plugin_name;
     return ()
 
   let supports_feature scheme feature =
-    match Hashtbl.find !table scheme with
+    match Hashtbl.find table scheme with
     | None -> false
-    | Some query_result -> List.mem query_result.Xapi_storage.Plugin.Types.features feature ~equal:String.equal
+    | Some (_script_dir, query_result) -> List.mem query_result.Xapi_storage.Plugin.features feature ~equal:String.equal
 end
 
 let vdi_of_volume x =
-  let ty = match List.Assoc.find x.Xapi_storage.Volume.Types.keys _vdi_type_key ~equal:String.equal with
+  let ty = match List.Assoc.find x.Xapi_storage.Control.keys _vdi_type_key ~equal:String.equal with
     | None -> "";
     | Some v -> v in
-  let snapshot_time = match List.Assoc.find x.Xapi_storage.Volume.Types.keys _snapshot_time_key ~equal:String.equal with
+  let snapshot_time = match List.Assoc.find x.Xapi_storage.Control.keys _snapshot_time_key ~equal:String.equal with
     | None -> "19700101T00:00:00Z"
     | Some snapshot_time -> snapshot_time
   in
   let open Storage_interface in {
-  vdi = x.Xapi_storage.Volume.Types.key;
-  uuid = x.Xapi_storage.Volume.Types.uuid;
+  vdi = x.Xapi_storage.Control.key;
+  uuid = x.Xapi_storage.Control.uuid;
   content_id = "";
-  name_label = x.Xapi_storage.Volume.Types.name;
-  name_description = x.Xapi_storage.Volume.Types.description;
+  name_label = x.Xapi_storage.Control.name;
+  name_description = x.Xapi_storage.Control.description;
   ty = ty;
   metadata_of_pool = "";
   is_a_snapshot = false;
   snapshot_time;
   snapshot_of = "";
-  read_only = not x.Xapi_storage.Volume.Types.read_write;
+  read_only = not x.Xapi_storage.Control.read_write;
   cbt_enabled = false;
-  virtual_size = x.Xapi_storage.Volume.Types.virtual_size;
-  physical_utilisation = x.Xapi_storage.Volume.Types.physical_utilisation;
+  virtual_size = x.Xapi_storage.Control.virtual_size;
+  physical_utilisation = x.Xapi_storage.Control.physical_utilisation;
   sm_config = [];
-  sharable = x.Xapi_storage.Volume.Types.sharable;
+  sharable = x.Xapi_storage.Control.sharable;
   persistent = true;
 }
 
-let stat compat_out root_dir name dbg sr vdi =
-  let args = Xapi_storage.Volume.Types.Volume.Stat.In.make dbg sr vdi in
-  let args = Xapi_storage.Volume.Types.Volume.Stat.In.rpc_of_t args in
-  let t_of_rpc rpc =
-    rpc |>  compat_out ["sharable", R.Bool false] |> Xapi_storage.Volume.Types.Volume.Stat.Out.t_of_rpc in
-  fork_exec_rpc root_dir (script root_dir name `Volume "Volume.stat") args t_of_rpc
+module Compat(V : sig val version : string option ref end) = struct
+  (** Module for making the inputs and outputs compatible with the old PVS
+      version of the storage scripts. *)
 
-let clone root_dir name dbg sr vdi =
-  let args = Xapi_storage.Volume.Types.Volume.Clone.In.make dbg sr vdi in
-  let args = Xapi_storage.Volume.Types.Volume.Clone.In.rpc_of_t args in
-  fork_exec_rpc root_dir (script root_dir name `Volume "Volume.clone") args Xapi_storage.Volume.Types.Volume.Clone.Out.t_of_rpc
+  let remove field rpc =
+    match !V.version, rpc with
+    | Some v, R.Dict d when v = pvs_version ->
+        R.Dict (List.filter ~f:(fun (k,_) -> k <> field) d)
+    | _ -> rpc
 
-let destroy root_dir name dbg sr vdi =
-  let args = Xapi_storage.Volume.Types.Volume.Destroy.In.make dbg sr vdi in
-  let args = Xapi_storage.Volume.Types.Volume.Destroy.In.rpc_of_t args in
-  fork_exec_rpc root_dir (script root_dir name `Volume "Volume.destroy") args Xapi_storage.Volume.Types.Volume.Destroy.Out.t_of_rpc
+  let with_pvs_version f rpc = if !V.version = Some pvs_version then f rpc else rpc
 
-let set version root_dir name dbg sr vdi k v =
-  let args = Xapi_storage.Volume.Types.Volume.Set.In.make dbg sr vdi k v in
-  let args = Xapi_storage.Volume.Types.Volume.Set.In.rpc_of_t args in
-  (* this is wrong, we loose the VDI type, but old pvsproxy didn't have
-   * Volume.set and Volume.unset *)
-  let missing = if version = Some pvs_version then Some () else None in
-  fork_exec_rpc ?missing root_dir (script root_dir name `Volume "Volume.set") args Xapi_storage.Volume.Types.Volume.Set.Out.t_of_rpc
+  let add_to_input params =
+    with_pvs_version (function
+        (* Currently all parameters must be named. In this case, rpclib
+           currently puts them into a Dict. *)
+        | R.Dict d -> R.Dict (List.rev_append params d)
+        | rpc -> rpc)
 
-let unset version root_dir name dbg sr vdi k =
-  let args = Xapi_storage.Volume.Types.Volume.Unset.In.make dbg sr vdi k in
-  let args = Xapi_storage.Volume.Types.Volume.Unset.In.rpc_of_t args in
-  let missing = if version = Some pvs_version then Some () else None in
-  fork_exec_rpc ?missing root_dir (script root_dir name `Volume "Volume.unset") args Xapi_storage.Volume.Types.Volume.Unset.Out.t_of_rpc
+  let add_fields_to_dict fields =
+    function R.Dict d -> R.Dict (List.rev_append fields d) | rpc -> rpc
 
-let update_keys version root_dir name dbg sr key value response =
-  let open Deferred.Result.Monad_infix in
-  match value with
-  | None -> Deferred.Result.return response
-  | Some value ->
-     set version root_dir name dbg sr response.Xapi_storage.Volume.Types.key key value >>= fun () ->
-     Deferred.Result.return { response with keys = (key, value) :: response.keys }
+  let add_fields_to_record_output fields =
+    with_pvs_version (function
+        | R.Dict _ as d -> add_fields_to_dict fields d
+        | rpc -> rpc)
+
+  let add_fields_to_record_list_output fields =
+    with_pvs_version (function
+        | R.Enum l -> R.Enum (List.map ~f:(add_fields_to_dict fields) l)
+        | rpc -> rpc)
+
+  (** Add the missing [sharable] field to the Dict in [rpc], to ensure the
+      volume in the output match the new volume record type and is successfully
+      parsed by rpclib. *)
+  let compat_out_volume =
+    add_fields_to_record_output ["sharable", R.Bool false]
+
+  (** Add the missing [sharable] field to the Dicts in [rpc], to ensure the
+      volumes in the output match the new volume record type and are
+      successfully parsed by rpclib. *)
+  let compat_out_volumes =
+    add_fields_to_record_list_output ["sharable", R.Bool false]
+
+  (** For the old PVS version, adds the uri parameter to the call from
+      device_config, for newer versions, removes the uri key from device_config *)
+  let compat_uri device_config =
+    if !V.version = Some pvs_version then
+      match List.Assoc.find ~equal:String.equal device_config "uri" with
+      | None ->
+        return (Error (missing_uri ()))
+      | Some uri ->
+        return (Ok (device_config, add_to_input ["uri", R.String uri]))
+    else
+        return (Ok (List.Assoc.remove ~equal:String.equal device_config "uri", id))
+
+  (** Compatiblity for the old PVS version of SR.create, which had signature
+      [uri -> name -> desc -> config -> unit] *)
+  let sr_create device_config =
+    compat_uri device_config >>>= fun (device_config, compat_in) ->
+    let compat_out rpc =
+      (* The PVS version will return nothing *)
+      if rpc = R.Null then begin
+        Rpcmarshal.marshal Xapi_storage.Control.typ_of_configuration device_config
+      end else begin
+        rpc
+      end
+    in
+    return (Ok (device_config, compat_in, compat_out))
+end
 
 let choose_datapath ?(persistent = true) response =
   (* We can only use a URI with a valid scheme, since we use the scheme
@@ -325,54 +445,67 @@ let choose_datapath ?(persistent = true) response =
       match Uri.scheme uri with
       | None -> None
       | Some scheme -> Some (scheme, x)
-    ) response.Xapi_storage.Volume.Types.uri in
+    ) response.Xapi_storage.Control.uri in
   (* We can only use URIs whose schemes correspond to registered plugins *)
-  let possible = List.filter ~f:(fun (scheme, _) -> Hashtbl.mem !Datapath_plugins.table scheme) possible in
+  let possible = List.filter_map
+      ~f:(fun (scheme, uri) ->
+          match Hashtbl.find Datapath_plugins.table scheme with
+          | Some (script_dir, _query_result) -> Some (script_dir, scheme, uri)
+          | None -> None
+        )
+      possible
+  in
   (* If we want to be non-persistent, we prefer if the datapath plugin supports it natively *)
   let preference_order =
     if persistent
     then possible
     else
-      let supports_nonpersistent, others = List.partition_map ~f:(fun (scheme, uri) ->
-        if Datapath_plugins.supports_feature scheme _nonpersistent
-        then `Fst (scheme, uri) else `Snd (scheme, uri)
+      let supports_nonpersistent, others = List.partition_tf ~f:(fun (_script_dir, scheme, _uri) ->
+        Datapath_plugins.supports_feature scheme _nonpersistent
       ) possible in
       supports_nonpersistent @ others in
   match preference_order with
   | [] -> return (Error (missing_uri ()))
-  | (scheme, u) :: us -> return (Ok (scheme, u, "0"))
+  | (script_dir, scheme, u) :: us -> return (Ok (fork_exec_rpc ~script_dir, scheme, u, "0"))
 
 (* Process a message *)
-let process root_dir name =
-  (* Each `root_dir, name` pair (a plugin) has its own version, see the call to listen
-   * where `process` is partially applied.
-   *)
+let process_smapiv2_requests ~volume_script_dir =
+  (* Each plugin has its own version, see the call to listen
+     where `process` is partially applied. *)
   let version = ref None in
-  let compat_in field rpc =
-    match !version, rpc with
-    | Some v, R.Dict d when v = pvs_version ->
-        R.Dict (List.filter ~f:(fun (k,_) -> k <> field) d)
-    | _ -> rpc
+  let volume_rpc = fork_exec_rpc ~script_dir:volume_script_dir in
+  let module Compat = Compat(struct let version = version end) in
+
+  let stat ~dbg ~sr ~vdi =
+    (* TODO add default value to sharable? *)
+    return_volume_rpc (fun () -> Volume_client.stat (volume_rpc ~compat_out:Compat.compat_out_volume) dbg sr vdi)
   in
-  let rec compat_out fields rpc =
-    match !version, rpc with
-    | Some v, R.Dict d when v = pvs_version ->
-        R.Dict (List.rev_append fields d)
-    | Some v, R.Enum l when v = pvs_version ->
-        R.Enum (List.map ~f:(compat_out fields) l)
-    | _ -> rpc
+  let clone ~dbg ~sr ~vdi =
+    return_volume_rpc (fun () -> Volume_client.clone volume_rpc dbg sr vdi)
   in
-  let compat_uri device_config ~f =
-    if !version = Some pvs_version then
-      match List.Assoc.find ~equal:String.equal device_config "uri" with
-      | None ->
-        return (Error (missing_uri ()))
-      | Some uri ->
-        return (Ok (device_config |> f |> compat_out ["uri", R.String uri]))
-    else
-        List.Assoc.remove ~equal:String.equal device_config "uri" |> f |>
-        Deferred.Result.return
+  let destroy ~dbg ~sr ~vdi =
+    return_volume_rpc (fun () -> Volume_client.destroy volume_rpc dbg sr vdi)
   in
+  let set ~dbg ~sr ~vdi ~key ~value =
+    (* this is wrong, we loose the VDI type, but old pvsproxy didn't have
+     * Volume.set and Volume.unset *)
+    (* TODO handle this properly? *)
+    let missing = if !version = Some pvs_version then Some (R.rpc_of_unit ()) else None in
+    return_volume_rpc (fun () -> Volume_client.set (volume_rpc ?missing) dbg sr vdi key value)
+  in
+  let unset ~dbg ~sr ~vdi ~key =
+    let missing = if !version = Some pvs_version then Some (R.rpc_of_unit ()) else None in
+    return_volume_rpc (fun () -> Volume_client.unset (volume_rpc ?missing) dbg sr vdi key)
+  in
+  let update_keys ~dbg ~sr ~key ~value response =
+    let open Deferred.Result.Monad_infix in
+    match value with
+    | None -> Deferred.Result.return response
+    | Some value ->
+       set ~dbg ~sr ~vdi:response.Xapi_storage.Control.key ~key ~value >>= fun () ->
+       Deferred.Result.return { response with keys = (key, value) :: response.keys }
+  in
+
   (* the actual API call for this plugin, sharing same version ref across all calls *)
   fun x ->
   let open Storage_interface in
@@ -381,21 +514,20 @@ let process root_dir name =
   | { R.name = "Query.query"; R.params = [ args ] } ->
     let args = Args.Query.Query.request_of_rpc args in
     (* convert to new storage interface *)
-    let args = Xapi_storage.Plugin.Types.Plugin.Query.In.make args.Args.Query.Query.dbg in
-    let args = Xapi_storage.Plugin.Types.Plugin.Query.In.rpc_of_t args in
+    let dbg = args.Args.Query.Query.dbg in
     let open Deferred.Result.Monad_infix in
-    fork_exec_rpc root_dir (script root_dir name `Volume "Plugin.Query") args Xapi_storage.Plugin.Types.Plugin.Query.Out.t_of_rpc
+    return_plugin_rpc (fun () -> Plugin_client.query volume_rpc dbg)
     >>= fun response ->
     (* Convert between the xapi-storage interface and the SMAPI *)
     let features = List.map ~f:(function
       | "VDI_DESTROY" -> "VDI_DELETE"
-      | x -> x) response.Xapi_storage.Plugin.Types.features in
+      | x -> x) response.Xapi_storage.Plugin.features in
     (* Look for executable scripts and automatically add capabilities *)
     let rec loop acc = function
       | [] -> return (Ok acc)
       | (s, capability) :: rest ->
         let open Deferred.Monad_infix in
-        let script_name = script root_dir name `Volume s in
+        let script_name = script_path ~script_dir:volume_script_dir ~call_name:call.R.name in
         ( Sys.is_file ~follow_symlinks:true script_name
           >>= function
           | `No | `Unknown ->
@@ -439,22 +571,22 @@ let process root_dir name =
       if List.mem features "VDI_CLONE" ~equal:String.equal
       then "VDI_RESET_ON_BOOT/2" :: features
       else features in
-    let name = response.Xapi_storage.Plugin.Types.name in
+    let name = response.Xapi_storage.Plugin.name in
     let required_api_version =
-      response.Xapi_storage.Plugin.Types.required_api_version in
+      response.Xapi_storage.Plugin.required_api_version in
     let response = {
-      driver = response.Xapi_storage.Plugin.Types.plugin;
+      driver = response.Xapi_storage.Plugin.plugin;
       name;
-      description = response.Xapi_storage.Plugin.Types.description;
-      vendor = response.Xapi_storage.Plugin.Types.vendor;
-      copyright = response.Xapi_storage.Plugin.Types.copyright;
-      version = response.Xapi_storage.Plugin.Types.version;
+      description = response.Xapi_storage.Plugin.description;
+      vendor = response.Xapi_storage.Plugin.vendor;
+      copyright = response.Xapi_storage.Plugin.copyright;
+      version = response.Xapi_storage.Plugin.version;
       required_api_version;
       features;
       configuration =
        ("uri", "URI of the storage medium") ::
-       response.Xapi_storage.Plugin.Types.configuration;
-      required_cluster_stack = response.Xapi_storage.Plugin.Types.required_cluster_stack } in
+       response.Xapi_storage.Plugin.configuration;
+      required_cluster_stack = response.Xapi_storage.Plugin.required_cluster_stack } in
     (* the first call to a plugin must be a Query.query that sets the version *)
     version := Some required_api_version;
     if required_api_version <> api_max then
@@ -464,39 +596,26 @@ let process root_dir name =
     else
       let msg = Printf.sprintf "%s requires unknown SMAPI API version %s, supported: %s"
         name required_api_version (String.concat ~sep:"," supported_api_versions) in
-      Exception.No_storage_plugin_for_sr msg
-      |> Exception.rpc_of_exnty |> R.failure |> Deferred.Result.return
+      return (Error (Exception.No_storage_plugin_for_sr msg))
   | { R.name = "Query.diagnostics"; R.params = [ args ] } ->
-    let args = Args.Query.Diagnostics.request_of_rpc args in
-    let args = Xapi_storage.Plugin.Types.Plugin.Diagnostics.In.make args.Args.Query.Diagnostics.dbg in
-    let args = Xapi_storage.Plugin.Types.Plugin.Diagnostics.In.rpc_of_t args in
     let open Deferred.Result.Monad_infix in
-    fork_exec_rpc root_dir (script root_dir name `Volume "Plugin.diagnostics") args Xapi_storage.Plugin.Types.Plugin.Diagnostics.Out.t_of_rpc
+    let args = Args.Query.Diagnostics.request_of_rpc args in
+    let dbg = args.Args.Query.Diagnostics.dbg in
+    return_plugin_rpc (fun () -> Plugin_client.diagnostics volume_rpc dbg)
     >>= fun response ->
     Deferred.Result.return (R.success (Args.Query.Diagnostics.rpc_of_response response))
   | { R.name = "SR.attach"; R.params = [ args ] } ->
     let args = Args.SR.Attach.request_of_rpc args in
     let device_config = args.Args.SR.Attach.device_config in
-    let uuid = args.Args.SR.Attach.sr in
-    compat_uri device_config ~f:(fun device_config ->
-      let device_config = ("sr_uuid", uuid) :: device_config in
-      let args' = Xapi_storage.Volume.Types.SR.Attach.In.make args.Args.SR.Attach.dbg device_config in
-      Xapi_storage.Volume.Types.SR.Attach.In.rpc_of_t args')
-    >>>= fun args' ->
-    begin
-      let open Deferred.Result.Monad_infix in
-      fork_exec_rpc root_dir (script root_dir name `Volume "SR.attach") args' Xapi_storage.Volume.Types.SR.Attach.Out.t_of_rpc
-      >>= fun attach_response ->
-      let sr = args.Args.SR.Attach.sr in
-      (* Stat the SR to look for datasources *)
-      let args = Xapi_storage.Volume.Types.SR.Stat.In.make
-        args.Args.SR.Attach.dbg
-        attach_response (* SR.stat should take the attached URI *) in
-      let args = Xapi_storage.Volume.Types.SR.Stat.In.rpc_of_t args in
-      fork_exec_rpc root_dir (script root_dir name `Volume "SR.stat") args Xapi_storage.Volume.Types.SR.Stat.Out.t_of_rpc
-      >>= fun stat ->
-      let open Deferred.Monad_infix in
-      let rec loop acc = function
+    Compat.compat_uri device_config >>>= fun (device_config, compat_in) ->
+    return_volume_rpc (fun () -> Sr_client.attach (volume_rpc ~compat_in) args.Args.SR.Attach.dbg device_config)
+    >>>= fun attach_response ->
+    let sr = args.Args.SR.Attach.sr in
+    (* Stat the SR to look for datasources *)
+    (* SR.stat should take the attached URI *)
+    return_volume_rpc (fun () -> Sr_client.stat volume_rpc args.Args.SR.Attach.dbg attach_response)
+    >>>= fun stat ->
+    let rec loop acc = function
       | [] -> return acc
       | datasource :: datasources ->
         let uri = Uri.of_string datasource in
@@ -510,14 +629,12 @@ let process root_dir name =
               | Error x -> raise Rrd_interface.(Rrdd_error x) end
         | _ ->
           loop acc datasources in
-      loop [] stat.Xapi_storage.Volume.Types.datasources
-      >>= fun uids ->
-      let open Deferred.Result.Monad_infix in
-      (* associate the 'sr' from the plugin with the SR reference passed in *)
-      Attached_SRs.add sr attach_response uids
-      >>= fun () ->
-      Deferred.Result.return (R.success (Args.SR.Attach.rpc_of_response attach_response))
-    end
+    loop [] stat.Xapi_storage.Control.datasources
+    >>= fun uids ->
+    (* associate the 'sr' from the plugin with the SR reference passed in *)
+    Attached_SRs.add sr attach_response uids
+    >>>= fun () ->
+    Deferred.Result.return (R.success (Args.SR.Attach.rpc_of_response attach_response))
   | { R.name = "SR.detach"; R.params = [ args ] } ->
     let args = Args.SR.Detach.request_of_rpc args in
     begin Attached_SRs.find args.Args.SR.Detach.sr
@@ -526,16 +643,10 @@ let process root_dir name =
       (* ensure SR.detach is idempotent *)
       Deferred.Result.return (R.success (Args.SR.Detach.rpc_of_response ()))
     | Ok sr ->
-      let open Deferred.Result.Monad_infix in
-      let args' = Xapi_storage.Volume.Types.SR.Detach.In.make
-        args.Args.SR.Detach.dbg
-        sr in
-      let args' = Xapi_storage.Volume.Types.SR.Detach.In.rpc_of_t args' in
-      fork_exec_rpc root_dir (script root_dir name `Volume "SR.detach") args' Xapi_storage.Volume.Types.SR.Detach.Out.t_of_rpc
-      >>= fun response ->
+      return_volume_rpc (fun () -> Sr_client.detach volume_rpc args.Args.SR.Detach.dbg sr)
+      >>>= fun response ->
       Attached_SRs.get_uids args.Args.SR.Detach.sr
-      >>= fun uids ->
-      let open Deferred.Monad_infix in
+      >>>= fun uids ->
       let rec loop = function
       | [] -> return ()
       | datasource :: datasources ->
@@ -559,44 +670,36 @@ let process root_dir name =
     end
   | { R.name = "SR.probe"; R.params = [ args ] } ->
     let args = Args.SR.Probe.request_of_rpc args in
-    let name = args.Args.SR.Probe.queue in
     let device_config = args.Args.SR.Probe.device_config in
-    compat_uri device_config ~f:(fun device_config ->
-      let args = Xapi_storage.Volume.Types.SR.Probe.In.make
-        args.Args.SR.Probe.dbg
-        device_config in
-      Xapi_storage.Volume.Types.SR.Probe.In.rpc_of_t args)
-    >>>= fun args ->
-    begin
-      let open Deferred.Result.Monad_infix in
-      let scriptname = script root_dir name `Volume "SR.probe" in
-      fork_exec_rpc root_dir scriptname args Xapi_storage.Volume.Types.SR.Probe.Out.t_of_rpc
-      >>= fun response ->
+    return_volume_rpc (fun () -> Sr_client.probe volume_rpc args.Args.SR.Probe.dbg device_config)
+    >>>= fun response ->
         let pp_probe_result () probe_result =
-          Xapi_storage.Volume.Types.SR.Probe.Out.rpc_of_t [probe_result] |>
-          Jsonrpc.to_string
+          Rpcmarshal.marshal
+            Xapi_storage.Control.typ_of_probe_result
+            probe_result
+          |> Jsonrpc.to_string
         in
         response
         |> List.map ~f:(fun probe_result ->
-          let uuid = List.Assoc.find probe_result.Xapi_storage.Volume.Types.configuration ~equal:String.equal "sr_uuid" in
+          let uuid = List.Assoc.find probe_result.Xapi_storage.Control.configuration ~equal:String.equal "sr_uuid" in
           let open Deferred.Or_error in
           let smapiv2_probe ?sr_info () =
             { configuration=probe_result.configuration; complete=probe_result.complete; sr=sr_info; extra_info=probe_result.extra_info }
           in
-          match probe_result.Xapi_storage.Volume.Types.sr, probe_result.Xapi_storage.Volume.Types.complete, uuid with
+          match probe_result.Xapi_storage.Control.sr, probe_result.Xapi_storage.Control.complete, uuid with
           | _, false, Some _uuid ->
               errorf "A configuration with a uuid cannot be incomplete: %a" pp_probe_result probe_result
           | Some sr_stat, true, Some _uuid ->
               let sr_info = {
-                Storage_interface.name_label = sr_stat.Xapi_storage.Volume.Types.name;
-                sr_uuid = sr_stat.Xapi_storage.Volume.Types.uuid;
-                name_description = sr_stat.Xapi_storage.Volume.Types.description;
-                total_space = sr_stat.Xapi_storage.Volume.Types.total_space;
-                free_space = sr_stat.Xapi_storage.Volume.Types.free_space;
-                clustered = sr_stat.Xapi_storage.Volume.Types.clustered;
-                health = match sr_stat.Xapi_storage.Volume.Types.health with
-                  | Xapi_storage.Volume.Types.Healthy _ -> Healthy
-                  | Xapi_storage.Volume.Types.Recovering _ -> Recovering
+                Storage_interface.name_label = sr_stat.Xapi_storage.Control.name;
+                sr_uuid = sr_stat.Xapi_storage.Control.uuid;
+                name_description = sr_stat.Xapi_storage.Control.description;
+                total_space = sr_stat.Xapi_storage.Control.total_space;
+                free_space = sr_stat.Xapi_storage.Control.free_space;
+                clustered = sr_stat.Xapi_storage.Control.clustered;
+                health = match sr_stat.Xapi_storage.Control.health with
+                  | Xapi_storage.Control.Healthy _ -> Healthy
+                  | Xapi_storage.Control.Recovering _ -> Recovering
               } in
               return (smapiv2_probe ~sr_info ())
           | Some _sr, _, None ->
@@ -607,41 +710,22 @@ let process root_dir name =
               return (smapiv2_probe ()))
         |> Deferred.Or_error.combine_errors
         |> Deferred.Result.map_error ~f:(fun err ->
+            let scriptname = script_path ~script_dir:volume_script_dir ~call_name:call.R.name in
             backend_error "SCRIPT_FAILED" [scriptname; Error.to_string_hum err])
         >>>= fun results ->
         Storage_interface.Probe results |> Args.SR.Probe.rpc_of_response |> R.success |> Deferred.Result.return
-    end
   | { R.name = "SR.create"; R.params = [ args ] } ->
     let args = Args.SR.Create.request_of_rpc args in
     let name_label = args.Args.SR.Create.name_label in
     let uuid = args.Args.SR.Create.sr in
     let description = args.Args.SR.Create.name_description in
     let device_config = args.Args.SR.Create.device_config in
-    compat_uri device_config ~f:(fun device_config ->
-      let args = Xapi_storage.Volume.Types.SR.Create.In.make
-        args.Args.SR.Create.dbg
-        uuid
-        device_config
-        name_label
-        description
-      in
-      Xapi_storage.Volume.Types.SR.Create.In.rpc_of_t args
-      |> compat_in "uuid")
-    >>>= fun args ->
-    begin
-      let open Deferred.Result.Monad_infix in
-      let t_of_rpc rpc =
-        if rpc = R.Null then None
-        else Some (Xapi_storage.Volume.Types.SR.Create.Out.t_of_rpc rpc)
-      in
-      fork_exec_rpc root_dir (script root_dir name `Volume "SR.create") args t_of_rpc
-      >>= fun response ->
-      let new_device_config = match response with
-      | None -> device_config
-      | Some response -> response
-      in
+    Compat.sr_create device_config >>>= fun (device_config, compat_in, compat_out) ->
+    return_volume_rpc (fun () ->
+        Sr_client.create (volume_rpc ~compat_in ~compat_out)
+          args.Args.SR.Create.dbg uuid device_config name_label description)
+    >>>= fun new_device_config ->
       Deferred.Result.return (R.success (Args.SR.Create.rpc_of_response new_device_config))
-    end
   | { R.name = "SR.set_name_label"; R.params = [ args ] } ->
     let open Deferred.Result.Monad_infix in
     let args = Args.SR.Set_name_label.request_of_rpc args in
@@ -649,9 +733,7 @@ let process root_dir name =
     >>= fun sr ->
     let name_label = args.Args.SR.Set_name_label.new_name_label in
     let dbg = args.Args.SR.Set_name_label.dbg in
-    let args = Xapi_storage.Volume.Types.SR.Set_name.In.make dbg sr name_label in
-    let args = Xapi_storage.Volume.Types.SR.Set_name.In.rpc_of_t args in
-    fork_exec_rpc root_dir (script root_dir name `Volume "SR.set_name") args Xapi_storage.Volume.Types.SR.Set_name.Out.t_of_rpc
+    return_volume_rpc (fun () -> Sr_client.set_name volume_rpc dbg sr name_label)
     >>= fun () ->
     Deferred.Result.return (R.success (Args.SR.Set_name_label.rpc_of_response ()))
   | { R.name = "SR.set_name_description"; R.params = [ args ] } ->
@@ -661,9 +743,7 @@ let process root_dir name =
     >>= fun sr ->
     let name_description = args.Args.SR.Set_name_description.new_name_description in
     let dbg = args.Args.SR.Set_name_description.dbg in
-    let args = Xapi_storage.Volume.Types.SR.Set_description.In.make dbg sr name_description in
-    let args = Xapi_storage.Volume.Types.SR.Set_description.In.rpc_of_t args in
-    fork_exec_rpc root_dir (script root_dir name `Volume "SR.set_description") args Xapi_storage.Volume.Types.SR.Set_description.Out.t_of_rpc
+    return_volume_rpc (fun () -> Sr_client.set_description volume_rpc dbg sr name_description)
     >>= fun () ->
     Deferred.Result.return (R.success (Args.SR.Set_name_label.rpc_of_response ()))
   | { R.name = "SR.destroy"; R.params = [ args ] } ->
@@ -671,11 +751,7 @@ let process root_dir name =
     let args = Args.SR.Destroy.request_of_rpc args in
     Attached_SRs.find args.Args.SR.Destroy.sr
     >>= fun sr ->
-    let args = Xapi_storage.Volume.Types.SR.Destroy.In.make
-      args.Args.SR.Destroy.dbg
-      sr in
-    let args = Xapi_storage.Volume.Types.SR.Destroy.In.rpc_of_t args in
-    fork_exec_rpc root_dir (script root_dir name `Volume "SR.destroy") args Xapi_storage.Volume.Types.SR.Destroy.Out.t_of_rpc
+    return_volume_rpc (fun () -> Sr_client.destroy volume_rpc args.Args.SR.Destroy.dbg sr)
     >>= fun response ->
     Deferred.Result.return (R.success (Args.SR.Destroy.rpc_of_response response))
   | { R.name = "SR.scan"; R.params = [ args ] } ->
@@ -683,21 +759,16 @@ let process root_dir name =
     let args = Args.SR.Scan.request_of_rpc args in
     Attached_SRs.find args.Args.SR.Scan.sr
     >>= fun sr ->
-    let args = Xapi_storage.Volume.Types.SR.Ls.In.make
-      args.Args.SR.Scan.dbg
-      sr in
-    let args = Xapi_storage.Volume.Types.SR.Ls.In.rpc_of_t args in
-    let t_of_rpc rpc =
-      rpc |>  compat_out ["sharable", R.Bool false] |> Xapi_storage.Volume.Types.SR.Ls.Out.t_of_rpc in
-    fork_exec_rpc root_dir (script root_dir name `Volume "SR.ls") args t_of_rpc
-    >>= fun response ->
+    return_volume_rpc (fun () -> Sr_client.ls (volume_rpc ~compat_out:Compat.compat_out_volumes) args.Args.SR.Scan.dbg sr)
+    >>>= fun response ->
+    let response = Array.to_list response in
     (* Filter out volumes which are clone-on-boot transients *)
     let transients = List.fold ~f:(fun set x ->
-      match List.Assoc.find x.Xapi_storage.Volume.Types.keys _clone_on_boot_key ~equal:String.equal with
+      match List.Assoc.find x.Xapi_storage.Control.keys _clone_on_boot_key ~equal:String.equal with
       | None -> set
       | Some transient -> Set.add set transient
     ) ~init:(Core.String.Set.empty) response in
-    let response = List.filter ~f:(fun x -> not(Set.mem transients x.Xapi_storage.Volume.Types.key)) response in
+    let response = List.filter ~f:(fun x -> not(Set.mem transients x.Xapi_storage.Control.key)) response in
     let response = List.map ~f:vdi_of_volume response in
     Deferred.Result.return (R.success (Args.SR.Scan.rpc_of_response response))
   | { R.name = "VDI.create"; R.params = [ args ] } ->
@@ -707,18 +778,16 @@ let process root_dir name =
     >>= fun sr ->
     let vdi_info = args.Args.VDI.Create.vdi_info in
     let dbg = args.Args.VDI.Create.dbg in
-    let args = Xapi_storage.Volume.Types.Volume.Create.In.make
-      dbg
-      sr
-      vdi_info.name_label
-      vdi_info.name_description
-      vdi_info.virtual_size
-      vdi_info.sharable in
-    let args = Xapi_storage.Volume.Types.Volume.Create.In.rpc_of_t args |> compat_in "sharable" in
-    let t_of_rpc rpc =
-      rpc |>  compat_out ["sharable", R.Bool false] |> Xapi_storage.Volume.Types.Volume.Create.Out.t_of_rpc in
-    fork_exec_rpc root_dir (script root_dir name `Volume "Volume.create") args t_of_rpc
-    >>= update_keys !version root_dir name dbg sr _vdi_type_key (match vdi_info.ty with "" -> None | s -> Some s)
+    return_volume_rpc (fun () ->
+        Volume_client.create
+          (volume_rpc ~compat_out:Compat.compat_out_volume)
+          dbg
+          sr
+          vdi_info.name_label
+          vdi_info.name_description
+          vdi_info.virtual_size
+          vdi_info.sharable)
+    >>= update_keys ~dbg ~sr ~key:_vdi_type_key ~value:(match vdi_info.ty with "" -> None | s -> Some s)
     >>= fun response ->
     let response = vdi_of_volume response in
     Deferred.Result.return (R.success (Args.VDI.Create.rpc_of_response response))
@@ -727,17 +796,17 @@ let process root_dir name =
     let args = Args.VDI.Destroy.request_of_rpc args in
     Attached_SRs.find args.Args.VDI.Destroy.sr
     >>= fun sr ->
-    stat compat_out root_dir name args.Args.VDI.Destroy.dbg sr args.Args.VDI.Destroy.vdi
+    stat ~dbg:args.Args.VDI.Destroy.dbg ~sr ~vdi:args.Args.VDI.Destroy.vdi
     >>= fun response ->
     (* Destroy any clone-on-boot volume that might exist *)
-    ( match List.Assoc.find response.Xapi_storage.Volume.Types.keys _clone_on_boot_key ~equal:String.equal with
+    ( match List.Assoc.find response.Xapi_storage.Control.keys _clone_on_boot_key ~equal:String.equal with
       | None ->
         return (Ok ())
       | Some temporary ->
         (* Destroy the temporary disk we made earlier *)
-        destroy root_dir name args.Args.VDI.Destroy.dbg sr temporary
+        destroy ~dbg:args.Args.VDI.Destroy.dbg ~sr ~vdi:temporary
     ) >>= fun () ->
-    destroy root_dir name args.Args.VDI.Destroy.dbg sr args.Args.VDI.Destroy.vdi
+    destroy ~dbg:args.Args.VDI.Destroy.dbg ~sr ~vdi:args.Args.VDI.Destroy.vdi
     >>= fun () ->
     Deferred.Result.return (R.success (Args.VDI.Destroy.rpc_of_response ()))
   | { R.name = "VDI.snapshot"; R.params = [ args ] } ->
@@ -747,15 +816,10 @@ let process root_dir name =
     >>= fun sr ->
     let vdi_info = args.Args.VDI.Snapshot.vdi_info in
     let dbg = args.Args.VDI.Snapshot.dbg in
-    let args = Xapi_storage.Volume.Types.Volume.Snapshot.In.make
-      dbg
-      sr
-      vdi_info.vdi in
-    let args = Xapi_storage.Volume.Types.Volume.Snapshot.In.rpc_of_t args in
-    fork_exec_rpc root_dir (script root_dir name `Volume "Volume.snapshot") args Xapi_storage.Volume.Types.Volume.Snapshot.Out.t_of_rpc
+    return_volume_rpc (fun () -> Volume_client.snapshot volume_rpc dbg sr vdi_info.vdi)
     >>= fun response ->
     let now = Xapi_stdext_date.Date.(to_string (of_float (Unix.gettimeofday ()))) in
-    set !version root_dir name dbg sr response.Xapi_storage.Volume.Types.key _snapshot_time_key now
+    set ~dbg ~sr ~vdi:response.Xapi_storage.Control.key ~key:_snapshot_time_key ~value:now
     >>= fun () ->
     let response = { (vdi_of_volume response) with snapshot_time = now } in
     Deferred.Result.return (R.success (Args.VDI.Snapshot.rpc_of_response response))
@@ -765,7 +829,7 @@ let process root_dir name =
     Attached_SRs.find args.Args.VDI.Clone.sr
     >>= fun sr ->
     let vdi_info = args.Args.VDI.Clone.vdi_info in
-    clone root_dir name args.Args.VDI.Clone.dbg sr vdi_info.vdi
+    clone ~dbg:args.Args.VDI.Clone.dbg ~sr ~vdi:vdi_info.vdi
     >>= fun response ->
     let response = vdi_of_volume response in
     Deferred.Result.return (R.success (Args.VDI.Clone.rpc_of_response response))
@@ -777,9 +841,7 @@ let process root_dir name =
     let vdi = args.Args.VDI.Set_name_label.vdi in
     let new_name_label = args.Args.VDI.Set_name_label.new_name_label in
     let dbg = args.Args.VDI.Set_name_label.dbg in
-    let args = Xapi_storage.Volume.Types.Volume.Set_name.In.make dbg sr vdi new_name_label in
-    let args = Xapi_storage.Volume.Types.Volume.Set_name.In.rpc_of_t args in
-    fork_exec_rpc root_dir (script root_dir name `Volume "Volume.set_name") args Xapi_storage.Volume.Types.Volume.Set_name.Out.t_of_rpc
+    return_volume_rpc (fun () -> Volume_client.set_name volume_rpc dbg sr vdi new_name_label)
     >>= fun () ->
     Deferred.Result.return (R.success (Args.VDI.Set_name_label.rpc_of_response ()))
   | { R.name = "VDI.set_name_description"; R.params = [ args ] } ->
@@ -790,9 +852,7 @@ let process root_dir name =
     let vdi = args.Args.VDI.Set_name_description.vdi in
     let new_name_description = args.Args.VDI.Set_name_description.new_name_description in
     let dbg = args.Args.VDI.Set_name_description.dbg in
-    let args = Xapi_storage.Volume.Types.Volume.Set_description.In.make dbg sr vdi new_name_description in
-    let args = Xapi_storage.Volume.Types.Volume.Set_description.In.rpc_of_t args in
-    fork_exec_rpc root_dir (script root_dir name `Volume "Volume.set_description") args Xapi_storage.Volume.Types.Volume.Set_description.Out.t_of_rpc
+    return_volume_rpc (fun () -> Volume_client.set_description volume_rpc dbg sr vdi new_name_description)
     >>= fun () ->
     Deferred.Result.return (R.success (Args.VDI.Set_name_description.rpc_of_response ()))
   | { R.name = "VDI.resize"; R.params = [ args ] } ->
@@ -803,21 +863,19 @@ let process root_dir name =
     let vdi = args.Args.VDI.Resize.vdi in
     let new_size = args.Args.VDI.Resize.new_size in
     let dbg = args.Args.VDI.Resize.dbg in
-    let args = Xapi_storage.Volume.Types.Volume.Resize.In.make dbg sr vdi new_size in
-    let args = Xapi_storage.Volume.Types.Volume.Resize.In.rpc_of_t args in
-    fork_exec_rpc root_dir (script root_dir name `Volume "Volume.resize") args Xapi_storage.Volume.Types.Volume.Resize.Out.t_of_rpc
+    return_volume_rpc (fun () -> Volume_client.resize volume_rpc dbg sr vdi new_size)
     >>= fun () ->
     (* Now call Volume.stat to discover the size *)
-    stat compat_out root_dir name dbg sr vdi
+    stat ~dbg ~sr ~vdi
     >>= fun response ->
-    Deferred.Result.return (R.success (Args.VDI.Resize.rpc_of_response response.Xapi_storage.Volume.Types.virtual_size))
+    Deferred.Result.return (R.success (Args.VDI.Resize.rpc_of_response response.Xapi_storage.Control.virtual_size))
   | { R.name = "VDI.stat"; R.params = [ args ] } ->
     let open Deferred.Result.Monad_infix in
     let args = Args.VDI.Stat.request_of_rpc args in
     Attached_SRs.find args.Args.VDI.Stat.sr
     >>= fun sr ->
     let vdi = args.Args.VDI.Stat.vdi in
-    stat compat_out root_dir name args.Args.VDI.Stat.dbg sr vdi
+    stat ~dbg:args.Args.VDI.Stat.dbg ~sr ~vdi
     >>= fun response ->
     let response = vdi_of_volume response in
     Deferred.Result.return (R.success (Args.VDI.Stat.rpc_of_response response))
@@ -827,7 +885,7 @@ let process root_dir name =
     Attached_SRs.find args.Args.VDI.Introduce.sr
     >>= fun sr ->
     let vdi = args.Args.VDI.Introduce.location in
-    stat compat_out root_dir name args.Args.VDI.Introduce.dbg sr vdi
+    stat ~dbg:args.Args.VDI.Introduce.dbg ~sr ~vdi
     >>= fun response ->
     let response = vdi_of_volume response in
     Deferred.Result.return (R.success (Args.VDI.Introduce.rpc_of_response response))
@@ -837,27 +895,23 @@ let process root_dir name =
     Attached_SRs.find args.Args.VDI.Attach.sr
     >>= fun sr ->
     (* Discover the URIs using Volume.stat *)
-    stat compat_out root_dir name args.Args.VDI.Attach.dbg sr args.Args.VDI.Attach.vdi
+    stat ~dbg:args.Args.VDI.Attach.dbg ~sr ~vdi:args.Args.VDI.Attach.vdi
     >>= fun response ->
     (* If we have a clone-on-boot volume then use that instead *)
-    ( match List.Assoc.find response.Xapi_storage.Volume.Types.keys _clone_on_boot_key ~equal:String.equal with
+    ( match List.Assoc.find response.Xapi_storage.Control.keys _clone_on_boot_key ~equal:String.equal with
       | None ->
         return (Ok response)
       | Some temporary ->
-        stat compat_out root_dir name args.Args.VDI.Attach.dbg sr temporary
+        stat ~dbg:args.Args.VDI.Attach.dbg ~sr ~vdi:temporary
     ) >>= fun response ->
     choose_datapath response
-    >>= fun (datapath, uri, domain) ->
-    let args' = Xapi_storage.Datapath.Types.Datapath.Attach.In.make
-      args.Args.VDI.Attach.dbg
-      uri domain in
-    let args' = Xapi_storage.Datapath.Types.Datapath.Attach.In.rpc_of_t args' in
-    fork_exec_rpc root_dir (script root_dir name (`Datapath datapath) "Datapath.attach") args' Xapi_storage.Datapath.Types.Datapath.Attach.Out.t_of_rpc
+    >>= fun (rpc, datapath, uri, domain) ->
+    return_data_rpc (fun () -> Datapath_client.attach rpc args.Args.VDI.Attach.dbg uri domain)
     >>= fun response ->
-    let backend, params = match response.Xapi_storage.Datapath.Types.implementation with
-    | Xapi_storage.Datapath.Types.Blkback p -> "vbd", p
-    | Xapi_storage.Datapath.Types.Qdisk p -> "qdisk", p
-    | Xapi_storage.Datapath.Types.Tapdisk3 p -> "vbd3", p in
+    let backend, params = match response.Xapi_storage.Data.implementation with
+    | Xapi_storage.Data.Blkback p -> "vbd", p
+    | Xapi_storage.Data.Qdisk p -> "qdisk", p
+    | Xapi_storage.Data.Tapdisk3 p -> "vbd3", p in
     let attach_info = {
       params;
       xenstore_data = [ "backend-kind", backend ];
@@ -871,22 +925,18 @@ let process root_dir name =
     Attached_SRs.find args.Args.VDI.Activate.sr
     >>= fun sr ->
     (* Discover the URIs using Volume.stat *)
-    stat compat_out root_dir name args.Args.VDI.Activate.dbg sr args.Args.VDI.Activate.vdi
+    stat ~dbg:args.Args.VDI.Activate.dbg ~sr ~vdi:args.Args.VDI.Activate.vdi
     >>= fun response ->
     (* If we have a clone-on-boot volume then use that instead *)
-    ( match List.Assoc.find response.Xapi_storage.Volume.Types.keys _clone_on_boot_key ~equal:String.equal with
+    ( match List.Assoc.find response.Xapi_storage.Control.keys _clone_on_boot_key ~equal:String.equal with
       | None ->
         return (Ok response)
       | Some temporary ->
-        stat compat_out root_dir name args.Args.VDI.Activate.dbg sr temporary
+        stat ~dbg:args.Args.VDI.Activate.dbg ~sr ~vdi:temporary
     ) >>= fun response ->
     choose_datapath response
-    >>= fun (datapath, uri, domain) ->
-    let args' = Xapi_storage.Datapath.Types.Datapath.Activate.In.make
-      args.Args.VDI.Activate.dbg
-      uri domain in
-    let args' = Xapi_storage.Datapath.Types.Datapath.Activate.In.rpc_of_t args' in
-    fork_exec_rpc root_dir (script root_dir name (`Datapath datapath) "Datapath.activate") args' Xapi_storage.Datapath.Types.Datapath.Activate.Out.t_of_rpc
+    >>= fun (rpc, datapath, uri, domain) ->
+    return_data_rpc (fun () -> Datapath_client.activate rpc args.Args.VDI.Activate.dbg uri domain)
     >>= fun response ->
     Deferred.Result.return (R.success (Args.VDI.Activate.rpc_of_response ()))
   | { R.name = "VDI.deactivate"; R.params = [ args ] } ->
@@ -895,21 +945,17 @@ let process root_dir name =
     Attached_SRs.find args.Args.VDI.Deactivate.sr
     >>= fun sr ->
     (* Discover the URIs using Volume.stat *)
-    stat compat_out root_dir name args.Args.VDI.Deactivate.dbg sr args.Args.VDI.Deactivate.vdi
+    stat ~dbg:args.Args.VDI.Deactivate.dbg ~sr ~vdi:args.Args.VDI.Deactivate.vdi
     >>= fun response ->
-    ( match List.Assoc.find response.Xapi_storage.Volume.Types.keys _clone_on_boot_key ~equal:String.equal with
+    ( match List.Assoc.find response.Xapi_storage.Control.keys _clone_on_boot_key ~equal:String.equal with
       | None ->
         return (Ok response)
       | Some temporary ->
-        stat compat_out root_dir name args.Args.VDI.Deactivate.dbg sr temporary
+        stat ~dbg:args.Args.VDI.Deactivate.dbg ~sr ~vdi:temporary
     ) >>= fun response ->
     choose_datapath response
-    >>= fun (datapath, uri, domain) ->
-    let args' = Xapi_storage.Datapath.Types.Datapath.Deactivate.In.make
-      args.Args.VDI.Deactivate.dbg
-      uri domain in
-    let args' = Xapi_storage.Datapath.Types.Datapath.Deactivate.In.rpc_of_t args' in
-    fork_exec_rpc root_dir (script root_dir name (`Datapath datapath) "Datapath.deactivate") args' Xapi_storage.Datapath.Types.Datapath.Deactivate.Out.t_of_rpc
+    >>= fun (rpc, datapath, uri, domain) ->
+    return_data_rpc (fun () -> Datapath_client.deactivate rpc args.Args.VDI.Deactivate.dbg uri domain)
     >>= fun response ->
     Deferred.Result.return (R.success (Args.VDI.Deactivate.rpc_of_response ()))
   | { R.name = "VDI.detach"; R.params = [ args ] } ->
@@ -918,21 +964,17 @@ let process root_dir name =
     Attached_SRs.find args.Args.VDI.Detach.sr
     >>= fun sr ->
     (* Discover the URIs using Volume.stat *)
-    stat compat_out root_dir name args.Args.VDI.Detach.dbg sr args.Args.VDI.Detach.vdi
+    stat ~dbg:args.Args.VDI.Detach.dbg ~sr ~vdi:args.Args.VDI.Detach.vdi
     >>= fun response ->
-    ( match List.Assoc.find response.Xapi_storage.Volume.Types.keys _clone_on_boot_key ~equal:String.equal with
+    ( match List.Assoc.find response.Xapi_storage.Control.keys _clone_on_boot_key ~equal:String.equal with
       | None ->
         return (Ok response)
       | Some temporary ->
-        stat compat_out root_dir name args.Args.VDI.Detach.dbg sr temporary
+        stat ~dbg:args.Args.VDI.Detach.dbg ~sr ~vdi:temporary
     ) >>= fun response ->
     choose_datapath response
-    >>= fun (datapath, uri, domain) ->
-    let args' = Xapi_storage.Datapath.Types.Datapath.Detach.In.make
-      args.Args.VDI.Detach.dbg
-      uri domain in
-    let args' = Xapi_storage.Datapath.Types.Datapath.Detach.In.rpc_of_t args' in
-    fork_exec_rpc root_dir (script root_dir name (`Datapath datapath) "Datapath.detach") args' Xapi_storage.Datapath.Types.Datapath.Detach.Out.t_of_rpc
+    >>= fun (rpc, datapath, uri, domain) ->
+    return_data_rpc (fun () -> Datapath_client.detach rpc args.Args.VDI.Detach.dbg uri domain)
     >>= fun response ->
     Deferred.Result.return (R.success (Args.VDI.Detach.rpc_of_response ()))
   | { R.name = "SR.stat"; R.params = [ args ] } ->
@@ -940,22 +982,18 @@ let process root_dir name =
     let args = Args.SR.Stat.request_of_rpc args in
     Attached_SRs.find args.Args.SR.Stat.sr
     >>= fun sr ->
-    let args = Xapi_storage.Volume.Types.SR.Stat.In.make
-      args.Args.SR.Stat.dbg
-      sr in
-    let args = Xapi_storage.Volume.Types.SR.Stat.In.rpc_of_t args in
-    fork_exec_rpc root_dir (script root_dir name `Volume "SR.stat") args Xapi_storage.Volume.Types.SR.Stat.Out.t_of_rpc
+    return_volume_rpc (fun () -> Sr_client.stat volume_rpc args.Args.SR.Stat.dbg sr)
     >>= fun response ->
     let response = {
-      sr_uuid = response.Xapi_storage.Volume.Types.uuid;
-      name_label = response.Xapi_storage.Volume.Types.name;
-      name_description = response.Xapi_storage.Volume.Types.description;
-      total_space = response.Xapi_storage.Volume.Types.total_space;
-      free_space = response.Xapi_storage.Volume.Types.free_space;
-      clustered = response.Xapi_storage.Volume.Types.clustered;
-      health = match response.Xapi_storage.Volume.Types.health with
-        | Xapi_storage.Volume.Types.Healthy _ -> Healthy
-        | Xapi_storage.Volume.Types.Recovering _ -> Recovering
+      sr_uuid = response.Xapi_storage.Control.uuid;
+      name_label = response.Xapi_storage.Control.name;
+      name_description = response.Xapi_storage.Control.description;
+      total_space = response.Xapi_storage.Control.total_space;
+      free_space = response.Xapi_storage.Control.free_space;
+      clustered = response.Xapi_storage.Control.clustered;
+      health = match response.Xapi_storage.Control.health with
+        | Xapi_storage.Control.Healthy _ -> Healthy
+        | Xapi_storage.Control.Recovering _ -> Recovering
         ;
     } in
     Deferred.Result.return (R.success (Args.SR.Stat.rpc_of_response response))
@@ -966,35 +1004,31 @@ let process root_dir name =
     >>= fun sr ->
     (* Discover the URIs using Volume.stat *)
     let persistent = args.Args.VDI.Epoch_begin.persistent in
-    stat compat_out root_dir name args.Args.VDI.Epoch_begin.dbg sr args.Args.VDI.Epoch_begin.vdi
+    stat ~dbg:args.Args.VDI.Epoch_begin.dbg ~sr ~vdi:args.Args.VDI.Epoch_begin.vdi
     >>= fun response ->
     choose_datapath ~persistent response
-    >>= fun (datapath, uri, domain) ->
+    >>= fun (rpc, datapath, uri, domain) ->
     (* If non-persistent and the datapath plugin supports NONPERSISTENT
        then we delegate this to the datapath plugin. Otherwise we will
        make a temporary clone now and attach/detach etc this file. *)
     if Datapath_plugins.supports_feature datapath _nonpersistent then begin
       (* We delegate handling non-persistent disks to the datapath plugin. *)
-      let args = Xapi_storage.Datapath.Types.Datapath.Open.In.make
-        args.Args.VDI.Epoch_begin.dbg
-        uri persistent in
-      let args = Xapi_storage.Datapath.Types.Datapath.Open.In.rpc_of_t args in
-      fork_exec_rpc root_dir (script root_dir name (`Datapath datapath) "Datapath.open") args Xapi_storage.Datapath.Types.Datapath.Open.Out.t_of_rpc
+      return_data_rpc (fun () -> Datapath_client.open_ rpc args.Args.VDI.Epoch_begin.dbg uri persistent)
       >>= fun () ->
       Deferred.Result.return (R.success (Args.VDI.Epoch_begin.rpc_of_response ()))
     end else if not persistent then begin
       (* We create a non-persistent disk here with Volume.clone, and store
          the name of the cloned disk in the metadata of the original. *)
-      ( match List.Assoc.find response.Xapi_storage.Volume.Types.keys _clone_on_boot_key ~equal:String.equal with
+      ( match List.Assoc.find response.Xapi_storage.Control.keys _clone_on_boot_key ~equal:String.equal with
         | None ->
           return (Ok ())
         | Some temporary ->
           (* Destroy the temporary disk we made earlier *)
-          destroy root_dir name args.Args.VDI.Epoch_begin.dbg sr temporary
+          destroy ~dbg:args.Args.VDI.Epoch_begin.dbg ~sr ~vdi:temporary
       ) >>= fun () ->
-      clone root_dir name args.Args.VDI.Epoch_begin.dbg sr args.Args.VDI.Epoch_begin.vdi
+      clone ~dbg:args.Args.VDI.Epoch_begin.dbg ~sr ~vdi:args.Args.VDI.Epoch_begin.vdi
       >>= fun vdi ->
-      set !version root_dir name args.Args.VDI.Epoch_begin.dbg sr args.Args.VDI.Epoch_begin.vdi _clone_on_boot_key vdi.Xapi_storage.Volume.Types.key
+      set ~dbg:args.Args.VDI.Epoch_begin.dbg ~sr ~vdi:args.Args.VDI.Epoch_begin.vdi ~key:_clone_on_boot_key ~value:vdi.Xapi_storage.Control.key
       >>= fun () ->
       Deferred.Result.return (R.success (Args.VDI.Epoch_begin.rpc_of_response ()))
     end else Deferred.Result.return (R.success (Args.VDI.Epoch_begin.rpc_of_response ()))
@@ -1004,27 +1038,23 @@ let process root_dir name =
     Attached_SRs.find args.Args.VDI.Epoch_end.sr
     >>= fun sr ->
     (* Discover the URIs using Volume.stat *)
-    stat compat_out root_dir name args.Args.VDI.Epoch_end.dbg sr args.Args.VDI.Epoch_end.vdi
+    stat ~dbg:args.Args.VDI.Epoch_end.dbg ~sr ~vdi:args.Args.VDI.Epoch_end.vdi
     >>= fun response ->
     choose_datapath response
-    >>= fun (datapath, uri, domain) ->
+    >>= fun (rpc, datapath, uri, domain) ->
     if Datapath_plugins.supports_feature datapath _nonpersistent then begin
-      let args = Xapi_storage.Datapath.Types.Datapath.Close.In.make
-        args.Args.VDI.Epoch_end.dbg
-        uri in
-      let args = Xapi_storage.Datapath.Types.Datapath.Close.In.rpc_of_t args in
-      fork_exec_rpc root_dir (script root_dir name (`Datapath datapath) "Datapath.close") args Xapi_storage.Datapath.Types.Datapath.Close.Out.t_of_rpc
+      return_data_rpc (fun () -> Datapath_client.close rpc args.Args.VDI.Epoch_end.dbg uri)
       >>= fun () ->
       Deferred.Result.return (R.success (Args.VDI.Epoch_end.rpc_of_response ()))
     end else begin
-      match List.Assoc.find response.Xapi_storage.Volume.Types.keys _clone_on_boot_key ~equal:String.equal with
+      match List.Assoc.find response.Xapi_storage.Control.keys _clone_on_boot_key ~equal:String.equal with
       | None ->
         Deferred.Result.return (R.success (Args.VDI.Epoch_end.rpc_of_response ()))
       | Some temporary ->
         (* Destroy the temporary disk we made earlier *)
-        destroy root_dir name args.Args.VDI.Epoch_end.dbg sr temporary
+        destroy ~dbg:args.Args.VDI.Epoch_end.dbg ~sr ~vdi:temporary
         >>= fun () ->
-        unset !version root_dir name args.Args.VDI.Epoch_end.dbg sr args.Args.VDI.Epoch_end.vdi _clone_on_boot_key
+        unset ~dbg:args.Args.VDI.Epoch_end.dbg ~sr ~vdi:args.Args.VDI.Epoch_end.vdi ~key:_clone_on_boot_key
         >>= fun () ->
         Deferred.Result.return (R.success (Args.VDI.Epoch_end.rpc_of_response ()))
     end
@@ -1036,12 +1066,13 @@ let process root_dir name =
     Deferred.return (Error (backend_error "UNIMPLEMENTED" [ name ])))
   >>= function
   | Result.Error error ->
-    info "returning error %s" (Jsonrpc.string_of_response (R.failure error));
-    return (Jsonrpc.string_of_response (R.failure error))
+    let response = R.failure (Exception.rpc_of_exnty error) in
+    info "returning error %s" (Jsonrpc.string_of_response response);
+    return (Jsonrpc.string_of_response response)
   | Result.Ok rpc ->
     return (Jsonrpc.string_of_response rpc)
 
-(* Active servers, one per sub-directory of the root_dir *)
+(* Active servers, one per sub-directory of the volume_root_dir *)
 let servers = String.Table.create () ~size:4
 
 (* XXX: need a better error-handling strategy *)
@@ -1060,35 +1091,36 @@ let rec diff a b = match a with
   | a :: aa ->
     if List.mem b a ~equal:(=) then diff aa b else a :: (diff aa b)
 
-let watch_volume_plugins ~root_dir ~switch_path ~pipe =
-  let create switch_path root_dir name =
-    if Hashtbl.mem servers name
+let watch_volume_plugins ~volume_root ~switch_path ~pipe =
+  let create volume_plugin_name =
+    if Hashtbl.mem servers volume_plugin_name
       then return ()
       else begin
-        info "Adding %s" name;
-        Message_switch_async.Protocol_async.Server.listen ~process:(process root_dir name) ~switch:switch_path ~queue:(Filename.basename name) ()
+        info "Adding %s" volume_plugin_name;
+        let volume_script_dir = Filename.concat volume_root volume_plugin_name in
+        Message_switch_async.Protocol_async.Server.listen ~process:(process_smapiv2_requests ~volume_script_dir) ~switch:switch_path ~queue:(Filename.basename volume_plugin_name) ()
         >>= fun result ->
         let server = get_ok result in
-        Hashtbl.add_exn servers ~key:name ~data:server;
+        Hashtbl.add_exn servers ~key:volume_plugin_name ~data:server;
         return ()
       end in
-  let destroy switch_path name =
-    info "Removing %s" name;
-    if Hashtbl.mem servers name then begin
-      let t = Hashtbl.find_exn servers name in
+  let destroy volume_plugin_name =
+    info "Removing %s" volume_plugin_name;
+    if Hashtbl.mem servers volume_plugin_name then begin
+      let t = Hashtbl.find_exn servers volume_plugin_name in
       Message_switch_async.Protocol_async.Server.shutdown ~t () >>= fun () ->
-      Hashtbl.remove servers name;
+      Hashtbl.remove servers volume_plugin_name;
       return ()
     end else return () in
-  let sync ~root_dir ~switch_path =
-    Sys.readdir root_dir
+  let sync () =
+    Sys.readdir volume_root
     >>= fun names ->
     let needed : string list = Array.to_list names in
     let got_already : string list = Hashtbl.keys servers in
-    Deferred.all_ignore (List.map ~f:(create switch_path root_dir) (diff needed got_already))
+    Deferred.all_ignore (List.map ~f:create (diff needed got_already))
     >>= fun () ->
-    Deferred.all_ignore (List.map ~f:(destroy switch_path) (diff got_already needed)) in
-  sync ~root_dir ~switch_path
+    Deferred.all_ignore (List.map ~f:destroy (diff got_already needed)) in
+  sync ()
   >>= fun () ->
   let open Async_inotify.Event in
   let rec loop () =
@@ -1098,32 +1130,32 @@ let watch_volume_plugins ~root_dir ~switch_path ~pipe =
       Shutdown.exit 1
     | `Ok (Created path)
     | `Ok (Moved (Into path)) ->
-      create switch_path root_dir (Filename.basename path)
+      create (Filename.basename path)
     | `Ok (Unlinked path)
     | `Ok (Moved (Away path)) ->
-      destroy switch_path (Filename.basename path)
+      destroy (Filename.basename path)
     | `Ok (Modified _) ->
       return ()
     | `Ok (Moved (Move (path_a, path_b))) ->
-      destroy switch_path (Filename.basename path_a)
+      destroy (Filename.basename path_a)
       >>= fun () ->
-      create switch_path root_dir (Filename.basename path_b)
+      create (Filename.basename path_b)
     | `Ok Queue_overflow ->
-      sync ~root_dir ~switch_path
+      sync ()
     ) >>= fun () ->
     loop () in
   loop ()
 
-let watch_datapath_plugins ~root_dir ~pipe =
-  let sync ~root_dir =
-    Sys.readdir root_dir
+let watch_datapath_plugins ~datapath_root ~pipe =
+  let sync () =
+    Sys.readdir datapath_root
     >>= fun names ->
     let needed : string list = Array.to_list names in
     let got_already : string list = Hashtbl.keys servers in
-    Deferred.all_ignore (List.map ~f:(Datapath_plugins.register root_dir) (diff needed got_already))
+    Deferred.all_ignore (List.map ~f:(Datapath_plugins.register ~datapath_root) (diff needed got_already))
     >>= fun () ->
-    Deferred.all_ignore (List.map ~f:(Datapath_plugins.unregister root_dir) (diff got_already needed)) in
-  sync ~root_dir
+    Deferred.all_ignore (List.map ~f:Datapath_plugins.unregister (diff got_already needed)) in
+  sync ()
   >>= fun () ->
   let open Async_inotify.Event in
   let rec loop () =
@@ -1133,25 +1165,25 @@ let watch_datapath_plugins ~root_dir ~pipe =
       Shutdown.exit 1
     | `Ok (Created path)
     | `Ok (Moved (Into path)) ->
-      Datapath_plugins.register root_dir (Filename.basename path)
+      Datapath_plugins.register ~datapath_root (Filename.basename path)
     | `Ok (Unlinked path)
     | `Ok (Moved (Away path)) ->
-      Datapath_plugins.unregister root_dir (Filename.basename path)
+      Datapath_plugins.unregister (Filename.basename path)
     | `Ok (Modified _) ->
       return ()
     | `Ok (Moved (Move (path_a, path_b))) ->
-      Datapath_plugins.unregister root_dir (Filename.basename path_a)
+      Datapath_plugins.unregister (Filename.basename path_a)
       >>= fun () ->
-      Datapath_plugins.register root_dir (Filename.basename path_b)
+      Datapath_plugins.register ~datapath_root (Filename.basename path_b)
     | `Ok Queue_overflow ->
-      sync ~root_dir
+      sync ()
     ) >>= fun () ->
     loop () in
   loop ()
 
 let self_test_plugin ~root_dir plugin =
-  let volume_root = Filename.concat root_dir "volume" in
-  let process = process volume_root plugin in
+  let volume_script_dir = Filename.(concat (concat root_dir "volume") plugin) in
+  let process = process_smapiv2_requests ~volume_script_dir in
   let module Test = Storage_interface.ClientM(struct
     type 'a t = 'a Deferred.t
     let return = return
@@ -1239,8 +1271,8 @@ let main ~root_dir ~state_path ~switch_path =
     Monitor.try_with
       (fun () ->
         Deferred.all_unit [
-          watch_volume_plugins ~root_dir:volume_root ~switch_path ~pipe:volume;
-          watch_datapath_plugins ~root_dir:datapath_root ~pipe:datapath
+          watch_volume_plugins ~volume_root ~switch_path ~pipe:volume;
+          watch_datapath_plugins ~datapath_root ~pipe:datapath
         ]
       )
     >>= function


### PR DESCRIPTION
This PR also removes the working directory from the script invocation:
we do not set it explicitly any more.

It has passed two runs of the new quicktests.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>