### PR TITLE
Use syslog from xcp-idl for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,11 @@
 language: c
-sudo: false
-services:
-  - docker
-install:
-  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+sudo: required
+service: docker
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
 script: bash -ex .travis-docker.sh
 env:
   global:
-    - OCAML_VERSION=4.06
-    - DISTRO=debian-stable
-    - PACKAGE=xapi-storage-script
-  matrix:
     - BASE_REMOTE=git://github.com/xapi-project/xs-opam
-    - EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
+    - DISTRO="debian-9-ocaml-4.07"
+    - PACKAGE=xapi-storage-script
+    - PINS="xapi-storage-script:."

--- a/main.ml
+++ b/main.ml
@@ -91,8 +91,10 @@ let use_syslog = ref false
 let log level fmt =
   Printf.ksprintf (fun s ->
       if !use_syslog then begin
-        (* FIXME: this is synchronous and will block other I/O *)
-        Core.Unix.Syslog.syslog ~level ~facility:Core.Unix.Syslog.Facility.DAEMON s;
+        (* FIXME: this is synchronous and will block other I/O.
+         * This should use Log_extended.Syslog, but that brings in Core's Syslog module
+         * which conflicts with ours *)
+        Syslog.log Syslog.Daemon level s;
       end else begin
         let w = Lazy.force Writer.stderr in
         Writer.write w s;
@@ -100,10 +102,10 @@ let log level fmt =
       end
     ) fmt
 
-let debug fmt = log Core.Unix.Syslog.Level.DEBUG   fmt
-let info  fmt = log Core.Unix.Syslog.Level.INFO    fmt
-let warn  fmt = log Core.Unix.Syslog.Level.WARNING fmt
-let error fmt = log Core.Unix.Syslog.Level.ERR     fmt
+let debug fmt = log Syslog.Debug   fmt
+let info  fmt = log Syslog.Info   fmt
+let warn  fmt = log Syslog.Warning fmt
+let error fmt = log Syslog.Err     fmt
 
 let pvs_version = "3.0"
 let supported_api_versions = [pvs_version; "5.0"]


### PR DESCRIPTION
Core.Unix.Syslog got renamed to Syslog and made part of core.syslog.
However we cannot link that as it conflicts with the Syslog module in
xcp-idl (which is unwrapped).

For now switch to using the syslog module from xcp-idl instead.

In the future we should move to using wrapped modules, and Async.Log.Global/Log_extended.Syslog (see my log-extended branch), however that either requires updating all users of xapi-idl to use the wrapped module names, or at least to rename Syslog to Xcp_syslog everywhere it is used (not that many, but still lot of repos).

This will be needed if we want to upgrade to a newer version of Core (which we'd need to be able to get a newer version of ocaml)